### PR TITLE
perf(textlint-browser-runner): Add MomentLocalesPlugin

### DIFF
--- a/packages/textlint-browser-runner/package-lock.json
+++ b/packages/textlint-browser-runner/package-lock.json
@@ -4,6 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@azu/format-text": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.1.tgz",
+			"integrity": "sha1-aWc1CpRkD2sChVFpvYl85U1s6+I="
+		},
+		"@azu/style-format": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.0.tgz",
+			"integrity": "sha1-5wGH+Khi4ZGxvObAJo8TrNOlayA=",
+			"requires": {
+				"@azu/format-text": "^1.0.1"
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -299,8 +312,7 @@
 		"@babel/parser": {
 			"version": "7.8.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-			"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-			"dev": true
+			"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.8.3",
@@ -879,6 +891,15 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@bahmutov/data-driven": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@bahmutov/data-driven/-/data-driven-1.0.0.tgz",
+			"integrity": "sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==",
+			"requires": {
+				"check-more-types": "2.24.0",
+				"lazy-ass": "1.6.0"
+			}
+		},
 		"@sinonjs/commons": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
@@ -915,6 +936,34 @@
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
 		},
+		"@textlint-ja/textlint-rule-no-insert-dropping-sa": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@textlint-ja/textlint-rule-no-insert-dropping-sa/-/textlint-rule-no-insert-dropping-sa-1.0.1.tgz",
+			"integrity": "sha1-7zaBm+gwGZinZKh72OzKKo4ASEk=",
+			"requires": {
+				"array-find-index": "^1.0.2",
+				"kuromojin": "^1.3.2",
+				"morpheme-match-all": "^1.1.0"
+			}
+		},
+		"@textlint-rule/textlint-rule-no-invalid-control-character": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-invalid-control-character/-/textlint-rule-no-invalid-control-character-1.2.0.tgz",
+			"integrity": "sha512-FgkOQr14H8D/LQVAEOR2cGWhzItb9MXCAvaBwKkysIfP9Ngwam+8NRmbphQ/GrAm3PXV63QmK1xwAKM1DntwmQ==",
+			"requires": {
+				"execall": "^1.0.0"
+			}
+		},
+		"@textlint-rule/textlint-rule-no-unmatched-pair": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-unmatched-pair/-/textlint-rule-no-unmatched-pair-1.0.7.tgz",
+			"integrity": "sha512-ZZxnTWc9/rXfH10KfWZdEpB1rdTdBRUob7694GuKbppUGHgXV90kx5axxWsK78vA0sUeN6HXNy14cPSKqBrSiA==",
+			"requires": {
+				"sentence-splitter": "^3.0.11",
+				"textlint-rule-helper": "2.0.1",
+				"textlint-tester": "5.0.1"
+			}
+		},
 		"@textlint/ast-node-types": {
 			"version": "4.2.5",
 			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz",
@@ -944,6 +993,118 @@
 				"map-like": "^2.0.0"
 			}
 		},
+		"@textlint/fixer-formatter": {
+			"version": "3.1.13",
+			"resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-3.1.13.tgz",
+			"integrity": "sha512-FXqAJZ+5fLsOZjvFmn1JhCer8gQI4ZQk3R45bXizRJm6DASByPAGGh/MAQxxHSGeR5wR8miO/koxA2BrS8OhAw==",
+			"requires": {
+				"@textlint/module-interop": "^1.0.2",
+				"@textlint/types": "^1.3.1",
+				"chalk": "^1.1.3",
+				"debug": "^4.1.1",
+				"diff": "^4.0.1",
+				"is-file": "^1.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^6.0.0",
+				"text-table": "^0.2.0",
+				"try-resolve": "^1.0.1"
+			},
+			"dependencies": {
+				"@textlint/types": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/@textlint/types/-/types-1.3.1.tgz",
+					"integrity": "sha512-9MJ6PRPYWiFs2lfvp/Qhq72WrkZLL5ncBUXAVoj1Ug17ug8d7psmr/KJstMMocW3EWHSOuIDj7unh413c3jPqQ==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.5"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						}
+					}
+				},
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+						}
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
 		"@textlint/kernel": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-3.2.0.tgz",
@@ -963,12 +1124,167 @@
 				"structured-source": "^3.0.2"
 			}
 		},
+		"@textlint/linter-formatter": {
+			"version": "3.1.12",
+			"resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-3.1.12.tgz",
+			"integrity": "sha512-OEP4pklu01MEgBJrftD9vwe3HFx+jhiEe1JFIgf7GZ4a0fSer5vQWXBo5wHW6WtZtSa+iLBsLC3mI5VMeshzdA==",
+			"requires": {
+				"@azu/format-text": "^1.0.1",
+				"@azu/style-format": "^1.0.0",
+				"@textlint/module-interop": "^1.0.2",
+				"@textlint/types": "^1.3.1",
+				"chalk": "^1.0.0",
+				"concat-stream": "^1.5.1",
+				"debug": "^4.1.1",
+				"is-file": "^1.0.0",
+				"js-yaml": "^3.2.4",
+				"optionator": "^0.8.1",
+				"pluralize": "^2.0.0",
+				"string-width": "^1.0.1",
+				"string.prototype.padstart": "^3.0.0",
+				"strip-ansi": "^6.0.0",
+				"table": "^3.7.8",
+				"text-table": "^0.2.0",
+				"try-resolve": "^1.0.1",
+				"xml-escape": "^1.0.0"
+			},
+			"dependencies": {
+				"@textlint/types": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/@textlint/types/-/types-1.3.1.tgz",
+					"integrity": "sha512-9MJ6PRPYWiFs2lfvp/Qhq72WrkZLL5ncBUXAVoj1Ug17ug8d7psmr/KJstMMocW3EWHSOuIDj7unh413c3jPqQ==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.5"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						}
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+						}
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
+		"@textlint/markdown-to-ast": {
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.1.7.tgz",
+			"integrity": "sha512-B0QtokeQR4a9+4q0NQr8T9l7A1fFihTN5Ze57tVgqW+3ymzXEouh8DvPHeNQ4T6jEkAThvdjk95mxAMpGRJ79w==",
+			"requires": {
+				"@textlint/ast-node-types": "^4.2.5",
+				"debug": "^4.1.1",
+				"remark-frontmatter": "^1.2.0",
+				"remark-parse": "^5.0.0",
+				"structured-source": "^3.0.2",
+				"traverse": "^0.6.6",
+				"unified": "^6.1.6"
+			}
+		},
+		"@textlint/module-interop": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-1.0.2.tgz",
+			"integrity": "sha512-qQ6dqlg4SYywCywimIbkveQZu1MG6ugf6fcJuWDi3D51FbdkSRsMrPusJ1YoW6Y3XBp0ww9fJjXWtlUStGeQsw=="
+		},
+		"@textlint/regexp-string-matcher": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@textlint/regexp-string-matcher/-/regexp-string-matcher-1.1.0.tgz",
+			"integrity": "sha512-uTPnE1Dw1j+9clXPn61ZUdtg+WyhbgeXHwCTfBev7quHjeCP9PS8NdRkR6wEgmjuLg+xZlI4r/e1r6Bd0xyusQ==",
+			"requires": {
+				"escape-string-regexp": "^1.0.5",
+				"execall": "^1.0.0",
+				"lodash.sortby": "^4.7.0",
+				"lodash.uniq": "^4.5.0",
+				"lodash.uniqwith": "^4.5.0",
+				"to-regex": "^3.0.2"
+			}
+		},
 		"@textlint/text-to-ast": {
 			"version": "3.1.7",
 			"resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-3.1.7.tgz",
 			"integrity": "sha512-CBAEQmiEa2G/wonlLr1HgUtXfTSas6OGGvYGRIRMJweNh5Ilhbz2nM2/9XQMfLQbdn5pGYrAAAQRB2+/9fZ31A==",
 			"requires": {
 				"@textlint/ast-node-types": "^4.2.5"
+			}
+		},
+		"@textlint/textlint-plugin-markdown": {
+			"version": "5.1.12",
+			"resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-5.1.12.tgz",
+			"integrity": "sha512-CJWWTaomR22hQD3ogrZujMH1pNN7DqZadmx9CJXxgKwpI/cuD5d2kClwXO3MeLFckJr5HRso7SFN5ebqKu1ycw==",
+			"requires": {
+				"@textlint/markdown-to-ast": "^6.1.7"
 			}
 		},
 		"@textlint/textlint-plugin-text": {
@@ -996,6 +1312,21 @@
 			"version": "3.5.29",
 			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
 			"integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw=="
+		},
+		"@types/debug": {
+			"version": "0.0.30",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
+			"integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
+		},
+		"@types/structured-source": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/structured-source/-/structured-source-3.0.0.tgz",
+			"integrity": "sha512-8u+Wo5+GEXe4jZyQ8TplLp+1A7g32ZcVoE7VZu8VcxnlaEm5I/+T579R7q3qKN76jmK0lRshpo4hl4bj/kEPKA=="
+		},
+		"@types/unist": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.8.5",
@@ -1241,6 +1572,16 @@
 			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
 			"dev": true
 		},
+		"analyze-desumasu-dearu": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-3.1.0.tgz",
+			"integrity": "sha1-rza5SEVMB4OkMfKrk4pZ8k1A4VA=",
+			"requires": {
+				"array-find": "^1.0.0",
+				"kuromojin": "^1.2.1",
+				"object.assign": "^4.0.3"
+			}
+		},
 		"ansi-colors": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -1293,7 +1634,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -1316,6 +1656,16 @@
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
 		},
+		"array-find": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+			"integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg="
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		},
 		"array-flatten": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1327,6 +1677,15 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
+		},
+		"array.prototype.find": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+			"integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.13.0"
+			}
 		},
 		"asn1.js": {
 			"version": "4.10.1",
@@ -1369,8 +1728,15 @@
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"async": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"requires": {
+				"lodash": "^4.17.14"
+			}
 		},
 		"async-each": {
 			"version": "1.0.3",
@@ -1411,11 +1777,36 @@
 				"object.assign": "^4.1.0"
 			}
 		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+				}
+			}
+		},
+		"bail": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
@@ -1567,7 +1958,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1710,8 +2100,7 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
@@ -1786,6 +2175,11 @@
 			"integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
 			"dev": true
 		},
+		"ccount": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+			"integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
+		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1796,6 +2190,48 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
+		},
+		"character-entities": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+		},
+		"character-entities-legacy": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
+		},
+		"character-reference-invalid": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
+		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+		},
+		"check-ends-with-period": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/check-ends-with-period/-/check-ends-with-period-1.0.1.tgz",
+			"integrity": "sha1-19KdYUy8PtFatUGQ9P2k3qoxQdg=",
+			"requires": {
+				"array.prototype.find": "^2.0.3",
+				"emoji-regex": "^6.4.1",
+				"end-with": "^1.0.2"
+			},
+			"dependencies": {
+				"emoji-regex": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
+					"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ=="
+				}
+			}
+		},
+		"check-more-types": {
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+			"integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA="
 		},
 		"check-types": {
 			"version": "8.0.3",
@@ -1837,6 +2273,19 @@
 			"requires": {
 				"tslib": "^1.9.0"
 			}
+		},
+		"chrono-node": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.4.3.tgz",
+			"integrity": "sha512-ZyKcnTcr8i7Mt9p4+ixMHEuR6+eMTrjYCL9Rm9TZHviLleCtcZoVzmr2uSc+Vg8MX1YbNCnPbEd4rfV8WvzLcw==",
+			"requires": {
+				"dayjs": "^1.8.19"
+			}
+		},
+		"ci-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
 		},
 		"cipher-base": {
 			"version": "1.0.4",
@@ -1888,6 +2337,30 @@
 				"wrap-ansi": "^5.1.0"
 			}
 		},
+		"clone-regexp": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
+			"integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+			"requires": {
+				"is-regexp": "^1.0.0",
+				"is-supported-regexp-flag": "^1.0.0"
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"collapse-white-space": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
+		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1913,11 +2386,29 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
+		"comma-separated-tokens": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+			"integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
+		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
+		},
+		"commandpost": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.4.0.tgz",
+			"integrity": "sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ=="
+		},
+		"common-tags": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
+			"integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
+			"requires": {
+				"babel-runtime": "^6.26.0"
+			}
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -1934,14 +2425,12 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -2043,8 +2532,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"create-ecdh": {
 			"version": "4.0.3",
@@ -2096,6 +2584,11 @@
 				"which": "^1.2.9"
 			}
 		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+		},
 		"crypto-browserify": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -2120,6 +2613,11 @@
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
+		},
+		"dayjs": {
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.20.tgz",
+			"integrity": "sha512-mH0MCDxw6UCGJYxVN78h8ugWycZAO8thkj3bW6vApL5tS0hQplIDdAQcmbvl7n35H0AKdCJQaArTrIQw2xt4Qg=="
 		},
 		"debug": {
 			"version": "4.1.1",
@@ -2154,6 +2652,11 @@
 				"regexp.prototype.flags": "^1.2.0"
 			}
 		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
 		"define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -2166,7 +2669,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -2176,7 +2678,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2185,7 +2686,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2194,7 +2694,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -2248,11 +2747,37 @@
 				"randombytes": "^2.0.0"
 			}
 		},
+		"disparity": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
+			"integrity": "sha1-V92stHMkrl9Y0swNqIbbTOnutxg=",
+			"requires": {
+				"ansi-styles": "^2.0.1",
+				"diff": "^1.3.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"diff": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+					"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+				}
+			}
+		},
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
 			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
 			"dev": true
+		},
+		"doublearray": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
+			"integrity": "sha1-Yxhv6NNEEydtNiH2qg7F954ifvk="
 		},
 		"duplexer": {
 			"version": "0.1.1",
@@ -2332,6 +2857,11 @@
 				"once": "^1.4.0"
 			}
 		},
+		"end-with": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/end-with/-/end-with-1.0.2.tgz",
+			"integrity": "sha1-pDJ1WrT1Hn/HTzpxnGuB311mi9w="
+		},
 		"enhanced-resolve": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
@@ -2362,6 +2892,14 @@
 			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"requires": {
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -2398,11 +2936,18 @@
 			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
 			"dev": true
 		},
+		"escape-quotes": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/escape-quotes/-/escape-quotes-1.0.2.tgz",
+			"integrity": "sha1-tIltSmz4LdWzP0m3E0CMY4D2zZc=",
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint-scope": {
 			"version": "4.0.3",
@@ -2417,8 +2962,7 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esrecurse": {
 			"version": "4.2.1",
@@ -2434,6 +2978,11 @@
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
+		},
+		"estree-walker": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+			"integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig=="
 		},
 		"esutils": {
 			"version": "2.0.3",
@@ -2476,6 +3025,14 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
+			}
+		},
+		"execall": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+			"integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+			"requires": {
+				"clone-regexp": "^1.0.0"
 			}
 		},
 		"expand-brackets": {
@@ -2598,11 +3155,15 @@
 				}
 			}
 		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
 		"extend-shallow": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -2612,7 +3173,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -2696,11 +3256,32 @@
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"fault": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+			"requires": {
+				"format": "^0.2.0"
+			}
+		},
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
 			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
 			"dev": true
+		},
+		"file-entry-cache": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+			"requires": {
+				"flat-cache": "^2.0.1"
+			}
 		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
@@ -2819,6 +3400,36 @@
 				}
 			}
 		},
+		"flat-cache": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+			"requires": {
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
+		},
+		"flatmap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
+			"integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
+		},
+		"flatted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
+		},
 		"flush-write-stream": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -2829,11 +3440,21 @@
 				"readable-stream": "^2.3.6"
 			}
 		},
+		"folktale": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/folktale/-/folktale-2.0.1.tgz",
+			"integrity": "sha512-3kDSWVkSlErHIt/dC73vu+5zRqbW1mlnL46s2QfYN7Ps0JcS9MVtuLCrDQOBa7sanA+d9Fd8F+bn0VcyNe68Jw=="
+		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
+		},
+		"format": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -2890,8 +3511,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.2.11",
@@ -3468,6 +4088,11 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
+		"get-stdin": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+			"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
+		},
 		"get-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -3487,7 +4112,6 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -3562,8 +4186,7 @@
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-			"dev": true
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -3589,11 +4212,31 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				}
+			}
+		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
+		},
+		"has-only": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/has-only/-/has-only-1.1.1.tgz",
+			"integrity": "sha512-3GuFy9rDw0xvovCHb4SOKiRImbZ+a8boFBUyGNRPVd2mRyQOzYdau5G9nodUXC1ZKYN59hrHFkW1lgBQscYfTg=="
 		},
 		"has-symbols": {
 			"version": "1.0.1",
@@ -3652,6 +4295,34 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
+		"hast-util-from-parse5": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.2.tgz",
+			"integrity": "sha512-YXFjoRS7ES7PEoLx6uihtSfKTO1s3z/tzGiV5cVpsUiihduogFXubNRCzTIW3yOOGO1nws9CxPq4MbwD39Uo+w==",
+			"requires": {
+				"ccount": "^1.0.3",
+				"hastscript": "^5.0.0",
+				"property-information": "^5.0.0",
+				"web-namespaces": "^1.1.2",
+				"xtend": "^4.0.1"
+			}
+		},
+		"hast-util-parse-selector": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.3.tgz",
+			"integrity": "sha512-nxbeqjQNxsvo/uYYAw9kij6td05YVUlf1qti09rVfbWSLT5H6wo3c+USIwX6nzXWk5kFZzXnEqO82856r0aM2Q=="
+		},
+		"hastscript": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.1.tgz",
+			"integrity": "sha512-xHo1Hkcqd0LlWNuDL3/BxwhgAGp3d7uEvCMgCTrBY+zsOooPPH+8KAvW8PCgl+GB8H3H44nfSaF0A4BQ+4xlYg==",
+			"requires": {
+				"comma-separated-tokens": "^1.0.0",
+				"hast-util-parse-selector": "^2.0.0",
+				"property-information": "^5.0.0",
+				"space-separated-tokens": "^1.0.0"
+			}
+		},
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -3683,6 +4354,11 @@
 			"resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
 			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
 			"dev": true
+		},
+		"hosted-git-info": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
 		},
 		"http-errors": {
 			"version": "1.7.2",
@@ -3764,7 +4440,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -3773,8 +4448,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -3829,10 +4503,29 @@
 				}
 			}
 		},
+		"is-alphabetical": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+		},
+		"is-alphanumerical": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+			"requires": {
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0"
+			}
+		},
 		"is-arguments": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
 			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -3846,13 +4539,20 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-callable": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
 			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+		},
+		"is-ci": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"requires": {
+				"ci-info": "^1.0.0"
+			}
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
@@ -3878,6 +4578,11 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
 			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+		},
+		"is-decimal": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -3910,11 +4615,15 @@
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true
 		},
+		"is-file": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-file/-/is-file-1.0.0.tgz",
+			"integrity": "sha1-KKRM+9nT2xkwRfIrZfzo7fliBZY="
+		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-glob": {
 			"version": "4.0.1",
@@ -3924,6 +4633,11 @@
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
+		},
+		"is-hexadecimal": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -3945,11 +4659,15 @@
 				}
 			}
 		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -3962,11 +4680,21 @@
 				"has": "^1.0.3"
 			}
 		},
+		"is-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 			"dev": true
+		},
+		"is-supported-regexp-flag": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
+			"integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ=="
 		},
 		"is-symbol": {
 			"version": "1.0.3",
@@ -3976,11 +4704,26 @@
 				"has-symbols": "^1.0.1"
 			}
 		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-whitespace-character": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
+		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
 			"dev": true
+		},
+		"is-word-character": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
 		},
 		"is-wsl": {
 			"version": "1.1.0",
@@ -3991,8 +4734,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -4003,8 +4745,7 @@
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-			"dev": true
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
 		"jest-worker": {
 			"version": "25.1.0",
@@ -4043,7 +4784,6 @@
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -4058,8 +4798,7 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -4067,14 +4806,26 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "~0.0.0"
+			}
+		},
 		"json5": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
 			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
 			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"just-extend": {
 			"version": "4.0.2",
@@ -4085,8 +4836,30 @@
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+		},
+		"kuromoji": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.1.tgz",
+			"integrity": "sha1-Sqvzm8zti4rZLQB6BKJr5tqEd8k=",
+			"requires": {
+				"async": "^2.0.1",
+				"doublearray": "0.0.2",
+				"zlibjs": "^0.2.0"
+			}
+		},
+		"kuromojin": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+			"integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+			"requires": {
+				"kuromoji": "0.1.1"
+			}
+		},
+		"lazy-ass": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+			"integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM="
 		},
 		"lcid": {
 			"version": "2.0.0",
@@ -4110,6 +4883,34 @@
 			"dev": true,
 			"requires": {
 				"leven": "^3.1.0"
+			}
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				}
 			}
 		},
 		"loader-runner": {
@@ -4153,7 +4954,12 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+		},
+		"lodash.difference": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
 			"dev": true
 		},
 		"lodash.get": {
@@ -4161,6 +4967,21 @@
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+		},
+		"lodash.uniqwith": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+			"integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -4249,6 +5070,29 @@
 			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
+			}
+		},
+		"markdown-escapes": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
+		},
+		"match-index": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/match-index/-/match-index-1.0.3.tgz",
+			"integrity": "sha512-1XjyBWqCvEFFUDW/MPv0RwbITRD4xQXOvKoPYtLDq8IdZTfdF/cQSo5Yn4qvhfSSZgjgkTFsqJD2wOUG4ovV8Q==",
+			"requires": {
+				"regexp.prototype.flags": "^1.1.1"
+			}
+		},
+		"md5": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+			"requires": {
+				"charenc": "~0.0.1",
+				"crypt": "~0.0.1",
+				"is-buffer": "~1.1.1"
 			}
 		},
 		"md5.js": {
@@ -4381,7 +5225,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -4389,8 +5232,7 @@
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-			"dev": true
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"minipass": {
 			"version": "3.1.1",
@@ -4471,7 +5313,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			},
@@ -4479,8 +5320,7 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				}
 			}
 		},
@@ -4673,6 +5513,48 @@
 				}
 			}
 		},
+		"moji": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/moji/-/moji-0.5.1.tgz",
+			"integrity": "sha1-CI7s0cIsjzGiQK3PnJXlTzPrVPs=",
+			"requires": {
+				"object-assign": "^3.0.0"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+				}
+			}
+		},
+		"moment": {
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+		},
+		"moment-locales-webpack-plugin": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.1.2.tgz",
+			"integrity": "sha512-s+JE7lADQjUyeQvqB3sVcfxXncg1o+t5hrRl2GBY66vXuLO2tXIjD+4mNUXQMS10qCGoeK3R3skBrW34gHobBQ==",
+			"dev": true,
+			"requires": {
+				"lodash.difference": "^4.5.0"
+			}
+		},
+		"morpheme-match": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/morpheme-match/-/morpheme-match-1.2.1.tgz",
+			"integrity": "sha512-SSIcFPas4Dctx5PbrfKbW5XNADlkcn38LI+fqgB9QtminQ7FXeOR3//rnAmooZ1/5zTGeFoi8H9kFBAH9y1nfQ=="
+		},
+		"morpheme-match-all": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/morpheme-match-all/-/morpheme-match-all-1.2.0.tgz",
+			"integrity": "sha512-z8F1k4U8fAMcjkGBDWwVrKZLR8VSvKtYh6+5GZ9hi5mtXrYMILwDMgiPwfNGJvk/liQEG9/oNAJUcwLpyjI9Xg==",
+			"requires": {
+				"morpheme-match": "^1.2.1"
+			}
+		},
 		"move-concurrently": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -4750,6 +5632,53 @@
 				"path-to-regexp": "^1.7.0"
 			}
 		},
+		"nlcst-parse-japanese": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/nlcst-parse-japanese/-/nlcst-parse-japanese-1.2.0.tgz",
+			"integrity": "sha512-RAShLlpYa2z0voM219Ae3tqTug9UWle/Ob0ARXiP4Aq0PRaWQ7HkGCoWfmPP8tvVqwp0OmAGKNJHQ8xMmxw0/A==",
+			"requires": {
+				"kuromojin": "^1.4.0",
+				"nlcst-types": "^1.2.2",
+				"unist-types": "^1.1.4"
+			}
+		},
+		"nlcst-pattern-match": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/nlcst-pattern-match/-/nlcst-pattern-match-1.3.5.tgz",
+			"integrity": "sha512-A8jCuukQ9CXUjeYMe7QZ9lPLtdpzop5tnQjxs7cH9eVxs3jkQcQzCKRwdyQeSLaFg6l+f3P+j4OjcWHnf2VPWw==",
+			"requires": {
+				"@types/debug": "^0.0.30",
+				"debug": "^3.1.0",
+				"estree-walker": "^0.5.0",
+				"nlcst-to-string": "^2.0.0",
+				"nlcst-types": "^1.2.2",
+				"snap-shot-it": "^4.0.1",
+				"unist-types": "^1.1.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
+		"nlcst-to-string": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-2.0.3.tgz",
+			"integrity": "sha512-OY2QhGdf6jpYfHqS4vJwqF7aIBZkaMjMUkcHcskMPitvXLuYNGdQvgVWI/5yKwkmIdmhft3ounSJv+Re2yydng=="
+		},
+		"nlcst-types": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/nlcst-types/-/nlcst-types-1.2.2.tgz",
+			"integrity": "sha1-98K9U4WkbncpJLdZ//C6muIizc4=",
+			"requires": {
+				"unist-types": "^1.1.4"
+			}
+		},
 		"node-environment-flags": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -4822,6 +5751,17 @@
 				}
 			}
 		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4837,11 +5777,15 @@
 				"path-key": "^2.0.0"
 			}
 		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -4928,6 +5872,17 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"object.values": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+			"integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
+			}
+		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4941,7 +5896,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -4951,6 +5905,19 @@
 			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
 			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
 			"dev": true
+		},
+		"optionator": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.6",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"word-wrap": "~1.2.3"
+			}
 		},
 		"os-browserify": {
 			"version": "0.3.0",
@@ -5051,11 +6018,37 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
+		"parse-entities": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+			"requires": {
+				"character-entities": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"character-reference-invalid": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "^1.2.0"
+			}
+		},
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
+		},
+		"parse5": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
 		},
 		"parseurl": {
 			"version": "1.3.3",
@@ -5084,14 +6077,12 @@
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "2.0.1",
@@ -5102,8 +6093,12 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+		},
+		"path-to-glob-pattern": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-to-glob-pattern/-/path-to-glob-pattern-1.0.2.tgz",
+			"integrity": "sha1-Rz5qOikqnRP7rj7czuctO6uoxhk="
 		},
 		"path-to-regexp": {
 			"version": "1.8.0",
@@ -5119,6 +6114,23 @@
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
 					"dev": true
+				}
+			}
+		},
+		"path-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -5147,6 +6159,19 @@
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"dev": true
 		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"requires": {
+				"pinkie": "^2.0.0"
+			}
+		},
 		"pirates": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -5165,11 +6190,38 @@
 				"find-up": "^3.0.0"
 			}
 		},
+		"pluralize": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+			"integrity": "sha1-crcmqm+sHt7uQiVsfY3CVrM1Z38="
+		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
+		"prh": {
+			"version": "5.4.4",
+			"resolved": "https://registry.npmjs.org/prh/-/prh-5.4.4.tgz",
+			"integrity": "sha512-UATF+R/2H8owxwPvF12Knihu9aYGTuZttGHrEEq5NBWz38mREh23+WvCVKX3fhnIZIMV7ye6E1fnqAl+V6WYEw==",
+			"requires": {
+				"commandpost": "^1.2.1",
+				"diff": "^4.0.1",
+				"js-yaml": "^3.9.1"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+				}
+			}
 		},
 		"private": {
 			"version": "0.1.8",
@@ -5186,14 +6238,21 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
 			"dev": true
+		},
+		"property-information": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-5.4.0.tgz",
+			"integrity": "sha512-nmMWAm/3vKFGmmOWOcdLjgq/Hlxa+hsuR/px1Lp/UGEyc5A22A6l78Shc2C0E71sPmAqglni+HrS7L7VJ7AUCA==",
+			"requires": {
+				"xtend": "^4.0.0"
+			}
 		},
 		"proxy-addr": {
 			"version": "2.0.5",
@@ -5282,6 +6341,11 @@
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
 			"dev": true
 		},
+		"ramda": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+			"integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
+		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5319,11 +6383,128 @@
 				"unpipe": "1.0.0"
 			}
 		},
+		"rc-config-loader": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-3.0.0.tgz",
+			"integrity": "sha512-bwfUSB37TWkHfP+PPjb/x8BUjChFmmBK44JMfVnU7paisWqZl/o5k7ttCH+EQLnrbn2Aq8Fo1LAsyUiz+WF4CQ==",
+			"requires": {
+				"debug": "^4.1.1",
+				"js-yaml": "^3.12.0",
+				"json5": "^2.1.1",
+				"require-from-string": "^2.0.2"
+			}
+		},
+		"read-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"requires": {
+				"load-json-file": "^1.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^1.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+			"requires": {
+				"find-up": "^2.0.0",
+				"read-pkg": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				}
+			}
+		},
 		"readable-stream": {
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -5378,7 +6559,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -5430,6 +6610,52 @@
 				}
 			}
 		},
+		"regx": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/regx/-/regx-1.0.4.tgz",
+			"integrity": "sha1-oO4ywwiRCQIBnKERftQbnd0EGy8="
+		},
+		"rehype-parse": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.2.tgz",
+			"integrity": "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug==",
+			"requires": {
+				"hast-util-from-parse5": "^5.0.0",
+				"parse5": "^5.0.0",
+				"xtend": "^4.0.0"
+			}
+		},
+		"remark-frontmatter": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.2.tgz",
+			"integrity": "sha512-2eayxITZ8rezsXdgcXnYB3iLivohm2V/ZT4Ne8uhua6A4pk6GdLE2ZzJnbnINtD1HRLaTdB7RwF9sgUbMptJZA==",
+			"requires": {
+				"fault": "^1.0.1",
+				"xtend": "^4.0.1"
+			}
+		},
+		"remark-parse": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+			"integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+			"requires": {
+				"collapse-white-space": "^1.0.2",
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"is-word-character": "^1.0.0",
+				"markdown-escapes": "^1.0.0",
+				"parse-entities": "^1.1.0",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"trim": "0.0.1",
+				"trim-trailing-lines": "^1.0.0",
+				"unherit": "^1.0.4",
+				"unist-util-remove-position": "^1.0.0",
+				"vfile-location": "^2.0.0",
+				"xtend": "^4.0.1"
+			}
+		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -5445,14 +6671,23 @@
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"replace-ext": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"require-main-filename": {
 			"version": "2.0.0",
@@ -5464,7 +6699,6 @@
 			"version": "1.15.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
 			"integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -5516,8 +6750,7 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"rimraf": {
 			"version": "2.7.1",
@@ -5550,14 +6783,12 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -5582,8 +6813,7 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"send": {
 			"version": "0.17.1",
@@ -5628,6 +6858,40 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
+				}
+			}
+		},
+		"sentence-splitter": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-3.2.0.tgz",
+			"integrity": "sha512-lKX2tZ1rsA9Tu0gW8vRmMDmIEJoZ1d7cKpzcbFZdUrSpCR6gy/7OPPh7jjT/6Oc6Z79ToUmC2l8tyTEGanVmiA==",
+			"requires": {
+				"@textlint/ast-node-types": "^4.2.5",
+				"concat-stream": "^2.0.0",
+				"object.values": "^1.1.0",
+				"structured-source": "^3.0.2"
+			},
+			"dependencies": {
+				"concat-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+					"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^3.0.2",
+						"typedarray": "^0.0.6"
+					}
+				},
+				"readable-stream": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
 				}
 			}
 		},
@@ -5756,6 +7020,110 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
+				}
+			}
+		},
+		"slice-ansi": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+		},
+		"snap-shot-compare": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/snap-shot-compare/-/snap-shot-compare-2.7.1.tgz",
+			"integrity": "sha512-qJPyYskLyuOOON1rFjO5xHmeVduaNJGd6AgeWqq8F6rVE+n79Jr7wdML2qrODoAeb63zztd5JB9Cc8WSWV/rig==",
+			"requires": {
+				"check-more-types": "2.24.0",
+				"disparity": "2.0.0",
+				"folktale": "2.0.1",
+				"lazy-ass": "1.6.0",
+				"strip-ansi": "4.0.0",
+				"variable-diff": "1.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"snap-shot-core": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-5.0.4.tgz",
+			"integrity": "sha1-6y0WX+Nm4qhGDuPcJQt+whWWpSI=",
+			"requires": {
+				"check-more-types": "2.24.0",
+				"common-tags": "1.7.2",
+				"debug": "3.1.0",
+				"escape-quotes": "1.0.2",
+				"folktale": "2.1.0",
+				"is-ci": "1.1.0",
+				"jsesc": "2.5.1",
+				"lazy-ass": "1.6.0",
+				"mkdirp": "0.5.1",
+				"ramda": "0.25.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"folktale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/folktale/-/folktale-2.1.0.tgz",
+					"integrity": "sha512-eG9lWx/MAOPoFllqASH7d1+QMl6qCd+E+rOPSWgulFPKG55506kXKQZLnMg3fMHFZUWY/2POZUPc/MH7048nIg=="
+				},
+				"jsesc": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"snap-shot-it": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/snap-shot-it/-/snap-shot-it-4.1.5.tgz",
+			"integrity": "sha512-u4kipVWalEs6TDBsgZFCdtp3WVCv6Yy5FATmnkTv0kXuDmJaKXCym1KyqBLH2imW3bxLRR5ueNXmRYyid4ulag==",
+			"requires": {
+				"@bahmutov/data-driven": "1.0.0",
+				"check-more-types": "2.24.0",
+				"debug": "3.1.0",
+				"has-only": "1.1.1",
+				"ramda": "0.25.0",
+				"snap-shot-compare": "2.7.1",
+				"snap-shot-core": "5.0.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -5930,6 +7298,39 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
+		"space-separated-tokens": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+			"integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
+		},
+		"spdx-correct": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -5942,8 +7343,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"ssri": {
 			"version": "7.1.0",
@@ -5954,6 +7354,11 @@
 				"figgy-pudding": "^3.5.1",
 				"minipass": "^3.1.1"
 			}
+		},
+		"state-toggle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -6032,6 +7437,15 @@
 				"strip-ansi": "^5.1.0"
 			}
 		},
+		"string.prototype.padstart": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.1.0.tgz",
+			"integrity": "sha512-envqZvUp2JItI+OeQ5UAh1ihbAV5G/2bixTojvlIa090GGqF+NQRxbWb2nv9fTGrZABv6+pE6jXoAZhhS2k4Hw==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
+			}
+		},
 		"string.prototype.trimleft": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
@@ -6054,7 +7468,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -6066,6 +7479,14 @@
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^4.1.0"
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"requires": {
+				"is-utf8": "^0.2.0"
 			}
 		},
 		"strip-eof": {
@@ -6095,6 +7516,94 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
+			}
+		},
+		"table": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+			"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+			"requires": {
+				"ajv": "^4.7.0",
+				"ajv-keywords": "^1.0.0",
+				"chalk": "^1.1.1",
+				"lodash": "^4.0.0",
+				"slice-ansi": "0.0.4",
+				"string-width": "^2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+					"requires": {
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
+					}
+				},
+				"ajv-keywords": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+					"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
 			}
 		},
 		"tapable": {
@@ -6226,6 +7735,756 @@
 				}
 			}
 		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"textlint": {
+			"version": "11.6.3",
+			"resolved": "https://registry.npmjs.org/textlint/-/textlint-11.6.3.tgz",
+			"integrity": "sha512-tTLLgB49zkJgq6GYDJOT6F31kHLulFjzovCHpN6ycv8d/aPcYl9vv7f/luR33YBQZdnGLtn+j8+G4GJAZ6Uz6w==",
+			"requires": {
+				"@textlint/ast-node-types": "^4.2.5",
+				"@textlint/ast-traverse": "^2.1.7",
+				"@textlint/feature-flag": "^3.1.6",
+				"@textlint/fixer-formatter": "^3.1.13",
+				"@textlint/kernel": "^3.2.1",
+				"@textlint/linter-formatter": "^3.1.12",
+				"@textlint/module-interop": "^1.0.2",
+				"@textlint/textlint-plugin-markdown": "^5.1.12",
+				"@textlint/textlint-plugin-text": "^4.1.13",
+				"@textlint/types": "^1.3.1",
+				"@textlint/utils": "^1.0.3",
+				"debug": "^4.1.1",
+				"deep-equal": "^1.1.0",
+				"file-entry-cache": "^5.0.1",
+				"get-stdin": "^5.0.1",
+				"glob": "^7.1.3",
+				"is-file": "^1.0.0",
+				"log-symbols": "^1.0.2",
+				"map-like": "^2.0.0",
+				"md5": "^2.2.1",
+				"mkdirp": "^0.5.0",
+				"optionator": "^0.8.0",
+				"path-to-glob-pattern": "^1.0.2",
+				"rc-config-loader": "^3.0.0",
+				"read-pkg": "^1.1.0",
+				"read-pkg-up": "^3.0.0",
+				"structured-source": "^3.0.2",
+				"try-resolve": "^1.0.1",
+				"unique-concat": "^0.2.2"
+			},
+			"dependencies": {
+				"@textlint/ast-traverse": {
+					"version": "2.1.7",
+					"resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-2.1.7.tgz",
+					"integrity": "sha512-73Nw0R4TaskPmF36Hop1DZ8AbH339WrGiLQjzbOLaXHaBHQ4hdNw28UMlw4glfPZb7/zvxPcJRtg9AB8F3ZW0g==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.5"
+					}
+				},
+				"@textlint/kernel": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-3.2.1.tgz",
+					"integrity": "sha512-gMCgP/tAjCX8dGqgu7nhUwaDC/TzDKeRZb9qa50nqbnILRasKplj3lOWn2osZdkScVZPLQp+al1pDh9pU4D+Dw==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.5",
+						"@textlint/ast-tester": "^2.1.6",
+						"@textlint/ast-traverse": "^2.1.7",
+						"@textlint/feature-flag": "^3.1.6",
+						"@textlint/types": "^1.3.1",
+						"@textlint/utils": "^1.0.3",
+						"debug": "^4.1.1",
+						"deep-equal": "^1.1.0",
+						"map-like": "^2.0.0",
+						"structured-source": "^3.0.2"
+					}
+				},
+				"@textlint/textlint-plugin-text": {
+					"version": "4.1.13",
+					"resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-4.1.13.tgz",
+					"integrity": "sha512-KQfSYNDt8HSX8ZL/r86N8OrAuQ9LEuevAtGomtfkw0h7Ed/pUfmuYXjht8wYRdysYBa4JyjrXcmqzRAUdkWrag==",
+					"requires": {
+						"@textlint/text-to-ast": "^3.1.7"
+					}
+				},
+				"@textlint/types": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/@textlint/types/-/types-1.3.1.tgz",
+					"integrity": "sha512-9MJ6PRPYWiFs2lfvp/Qhq72WrkZLL5ncBUXAVoj1Ug17ug8d7psmr/KJstMMocW3EWHSOuIDj7unh413c3jPqQ==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.5"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"log-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"requires": {
+						"chalk": "^1.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
+		"textlint-rule-date-weekday-mismatch": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/textlint-rule-date-weekday-mismatch/-/textlint-rule-date-weekday-mismatch-1.0.5.tgz",
+			"integrity": "sha1-KsJWi+UUnWXUqaUH6aqIf31Qxgs=",
+			"requires": {
+				"chrono-node": "^1.2.5",
+				"moment": "^2.17.1"
+			}
+		},
+		"textlint-rule-helper": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.0.1.tgz",
+			"integrity": "sha512-QNGSOemLVxm1b0qnH5VpRY8uyHgfx/8M+St8wSy/d6mZh0abd+KAvhQSuO8cxmVeRKr/LRkhAB3+0QU5LKhLGw==",
+			"requires": {
+				"unist-util-visit": "^1.1.0"
+			}
+		},
+		"textlint-rule-ja-hiragana-keishikimeishi": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/textlint-rule-ja-hiragana-keishikimeishi/-/textlint-rule-ja-hiragana-keishikimeishi-1.0.2.tgz",
+			"integrity": "sha512-tu9z5PGNtAsoHwR/UgIYuLQ/JPHmpCJAJOG0yjscj9Y5unAkU1Yb1mL4im218WRZ7XRBqCFwWLmicX2IbvVXWw==",
+			"requires": {
+				"kuromojin": "^1.3.2",
+				"morpheme-match-all": "^1.1.0"
+			}
+		},
+		"textlint-rule-ja-no-mixed-period": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/textlint-rule-ja-no-mixed-period/-/textlint-rule-ja-no-mixed-period-2.1.1.tgz",
+			"integrity": "sha512-yCfRva4pl2Sa6Xsxhzkec9rGuqP4MBlGrQ7ZQIM9On9dMaeIVabcwniMbLfO1CzUBBe9xUaCF/8eE0zOi8g4/A==",
+			"requires": {
+				"check-ends-with-period": "^1.0.1",
+				"textlint-rule-helper": "^2.0.0"
+			}
+		},
+		"textlint-rule-ja-no-redundant-expression": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/textlint-rule-ja-no-redundant-expression/-/textlint-rule-ja-no-redundant-expression-3.0.1.tgz",
+			"integrity": "sha512-Ng1pLiELXqD8RnDbkSaQlQcCQQS6qhFJqbb8HUVs65/wq6Mb4h+gOJOS63yO8e9V7WAYDhjKePTcduu1xwsCfA==",
+			"requires": {
+				"@textlint/regexp-string-matcher": "^1.0.2",
+				"kuromojin": "^1.3.2",
+				"morpheme-match": "^1.2.1",
+				"morpheme-match-all": "^1.2.0",
+				"textlint-rule-helper": "^2.1.1",
+				"textlint-util-to-string": "^2.1.1"
+			},
+			"dependencies": {
+				"textlint-rule-helper": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.1.1.tgz",
+					"integrity": "sha512-6fxgHzoJVkjl3LaC1b2Egi+5wbhG4i0pU0knJmQujVhxIJ3D3AcQQZPs457xKAi5xKz1WayYeTeJ5jrD/hnO7g==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.1",
+						"@textlint/types": "^1.1.2",
+						"structured-source": "^3.0.2",
+						"unist-util-visit": "^1.1.0"
+					}
+				}
+			}
+		},
+		"textlint-rule-ja-no-weak-phrase": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/textlint-rule-ja-no-weak-phrase/-/textlint-rule-ja-no-weak-phrase-1.0.4.tgz",
+			"integrity": "sha1-o968atIxTqEG8sy4hIvoF/+s8gM=",
+			"requires": {
+				"kuromojin": "^1.3.1",
+				"morpheme-match": "^1.0.1",
+				"morpheme-match-all": "^1.1.0"
+			}
+		},
+		"textlint-rule-ja-unnatural-alphabet": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/textlint-rule-ja-unnatural-alphabet/-/textlint-rule-ja-unnatural-alphabet-2.0.1.tgz",
+			"integrity": "sha512-n93V8qh6OKdh8OB6yLT+9Xl8DSoZ7gWi51tWdhlLEPIWgBm18nLMgm6Ck+nVc3eENOdRcQURWUpCGotI8wTemA==",
+			"requires": {
+				"@textlint/regexp-string-matcher": "^1.0.2",
+				"match-index": "^1.0.1",
+				"regx": "^1.0.4"
+			}
+		},
+		"textlint-rule-max-comma": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/textlint-rule-max-comma/-/textlint-rule-max-comma-1.0.4.tgz",
+			"integrity": "sha1-9VXJfg0wOcp9oGz9GvrQ5fWJmjc=",
+			"requires": {
+				"sentence-splitter": "^2.0.0",
+				"unist-util-filter": "^0.2.1"
+			},
+			"dependencies": {
+				"sentence-splitter": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-2.3.2.tgz",
+					"integrity": "sha512-QnpHNykm4nI4T6mT+NoVayh9Ixl5DohYCSVqMgPJsO2WejOcqaYTh4HQOkmzaDzXH3NO5pif4z/hpo2NGtgNlg==",
+					"requires": {
+						"concat-stream": "^1.5.2",
+						"structured-source": "^3.0.2"
+					}
+				}
+			}
+		},
+		"textlint-rule-max-kanji-continuous-len": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/textlint-rule-max-kanji-continuous-len/-/textlint-rule-max-kanji-continuous-len-1.1.1.tgz",
+			"integrity": "sha1-y8xESIwG02xlCZ4S95d+OhXDt38=",
+			"requires": {
+				"match-index": "^1.0.1",
+				"textlint-rule-helper": "^2.0.0"
+			}
+		},
+		"textlint-rule-max-number-of-lines": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/textlint-rule-max-number-of-lines/-/textlint-rule-max-number-of-lines-1.0.3.tgz",
+			"integrity": "sha1-/OZh1QQjiESTlhZOgwd40CTy5Zs=",
+			"requires": {
+				"object-assign": "^4.0.1"
+			}
+		},
+		"textlint-rule-max-ten": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/textlint-rule-max-ten/-/textlint-rule-max-ten-2.0.3.tgz",
+			"integrity": "sha1-3MvA0BV+6Gp1csoApHqx+ld/BkU=",
+			"requires": {
+				"kuromojin": "^1.0.2",
+				"sentence-splitter": "^2.0.0",
+				"structured-source": "^3.0.2",
+				"textlint-rule-helper": "^2.0.0"
+			},
+			"dependencies": {
+				"sentence-splitter": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-2.3.2.tgz",
+					"integrity": "sha512-QnpHNykm4nI4T6mT+NoVayh9Ixl5DohYCSVqMgPJsO2WejOcqaYTh4HQOkmzaDzXH3NO5pif4z/hpo2NGtgNlg==",
+					"requires": {
+						"concat-stream": "^1.5.2",
+						"structured-source": "^3.0.2"
+					}
+				}
+			}
+		},
+		"textlint-rule-ng-word": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/textlint-rule-ng-word/-/textlint-rule-ng-word-1.0.0.tgz",
+			"integrity": "sha1-s4miOepLSZL0VeKvNrsGL8bkLTk="
+		},
+		"textlint-rule-no-double-negative-ja": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-double-negative-ja/-/textlint-rule-no-double-negative-ja-1.0.5.tgz",
+			"integrity": "sha1-ujDbQk3H74TO2m0QN4GxTNIMx2Q=",
+			"requires": {
+				"kuromojin": "^1.1.0"
+			}
+		},
+		"textlint-rule-no-doubled-conjunction": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunction/-/textlint-rule-no-doubled-conjunction-1.0.2.tgz",
+			"integrity": "sha1-JMboAUxrLhhLx6XUwabuE7swmTA=",
+			"requires": {
+				"kuromojin": "^1.1.0",
+				"sentence-splitter": "^2.0.0",
+				"textlint-rule-helper": "^1.1.5",
+				"textlint-util-to-string": "^1.2.0"
+			},
+			"dependencies": {
+				"sentence-splitter": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-2.3.2.tgz",
+					"integrity": "sha512-QnpHNykm4nI4T6mT+NoVayh9Ixl5DohYCSVqMgPJsO2WejOcqaYTh4HQOkmzaDzXH3NO5pif4z/hpo2NGtgNlg==",
+					"requires": {
+						"concat-stream": "^1.5.2",
+						"structured-source": "^3.0.2"
+					}
+				},
+				"textlint-rule-helper": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+					"integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
+					"requires": {
+						"unist-util-visit": "^1.1.0"
+					}
+				},
+				"textlint-util-to-string": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-1.2.1.tgz",
+					"integrity": "sha1-HPiZVtJ1VaVelYjAazWlDw0dRvk=",
+					"requires": {
+						"object-assign": "^4.0.1",
+						"structured-source": "^3.0.2"
+					}
+				}
+			}
+		},
+		"textlint-rule-no-doubled-conjunctive-particle-ga": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunctive-particle-ga/-/textlint-rule-no-doubled-conjunctive-particle-ga-1.1.0.tgz",
+			"integrity": "sha512-5uTZEw0S1j27DJ2vxdSqmqekZGuzOz2c8axtjJR1XiLc/miB8f7Rz3S16Mq+M2W06wcJTdoM87ix5XWa+4oe8A==",
+			"requires": {
+				"kuromojin": "^1.1.0",
+				"sentence-splitter": "^1.2.0",
+				"textlint-rule-helper": "^1.1.5",
+				"textlint-util-to-string": "^1.2.0"
+			},
+			"dependencies": {
+				"sentence-splitter": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-1.2.0.tgz",
+					"integrity": "sha1-wcOEFM8UXscX/UN8rCDJiOD9DUY=",
+					"requires": {
+						"structured-source": "^3.0.2"
+					}
+				},
+				"textlint-rule-helper": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+					"integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
+					"requires": {
+						"unist-util-visit": "^1.1.0"
+					}
+				},
+				"textlint-util-to-string": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-1.2.1.tgz",
+					"integrity": "sha1-HPiZVtJ1VaVelYjAazWlDw0dRvk=",
+					"requires": {
+						"object-assign": "^4.0.1",
+						"structured-source": "^3.0.2"
+					}
+				}
+			}
+		},
+		"textlint-rule-no-doubled-joshi": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-joshi/-/textlint-rule-no-doubled-joshi-3.7.2.tgz",
+			"integrity": "sha512-6du7XciMGZuvAdEL0vAA7JSXVS9NbtWwsbVCeJ8ynSl4hNI+g9tGeN6zYZARJD6/cyklP+zFSvXixKf6nFFqMA==",
+			"requires": {
+				"kuromojin": "^2.0.0",
+				"sentence-splitter": "^3.2.0",
+				"textlint-rule-helper": "^2.1.1",
+				"textlint-util-to-string": "^3.0.0"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+				},
+				"is-plain-obj": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+				},
+				"kuromojin": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-2.0.0.tgz",
+					"integrity": "sha512-60j/yLkFSc4t4roj8tI8ZNNSiAFnrkgXw8SqXz/9nakfs6mkCvPbrd7S8LDr4YNwEt1IyLys5JQTR9EnYyGHhA==",
+					"requires": {
+						"kuromoji": "0.1.1"
+					}
+				},
+				"textlint-rule-helper": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.1.1.tgz",
+					"integrity": "sha512-6fxgHzoJVkjl3LaC1b2Egi+5wbhG4i0pU0knJmQujVhxIJ3D3AcQQZPs457xKAi5xKz1WayYeTeJ5jrD/hnO7g==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.1",
+						"@textlint/types": "^1.1.2",
+						"structured-source": "^3.0.2",
+						"unist-util-visit": "^1.1.0"
+					}
+				},
+				"textlint-util-to-string": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-3.0.0.tgz",
+					"integrity": "sha512-NLvumkbmdynXZIYdv9JR2amjsT8ZiPPmr/6vFLcJU2NmZTtZoE8DfEOW9BtD/pbUAQaukwGjbEFc93lBIL1o/w==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.4",
+						"@types/structured-source": "^3.0.0",
+						"rehype-parse": "^6.0.1",
+						"structured-source": "^3.0.2",
+						"unified": "^8.4.0"
+					}
+				},
+				"unified": {
+					"version": "8.4.2",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+					"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+					"requires": {
+						"bail": "^1.0.0",
+						"extend": "^3.0.0",
+						"is-plain-obj": "^2.0.0",
+						"trough": "^1.0.0",
+						"vfile": "^4.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
+					"integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
+					"requires": {
+						"@types/unist": "^2.0.2"
+					}
+				},
+				"vfile": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
+					"integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"is-buffer": "^2.0.0",
+						"replace-ext": "1.0.0",
+						"unist-util-stringify-position": "^2.0.0",
+						"vfile-message": "^2.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
+					"integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^2.0.0"
+					}
+				}
+			}
+		},
+		"textlint-rule-no-dropping-the-ra": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-dropping-the-ra/-/textlint-rule-no-dropping-the-ra-1.1.2.tgz",
+			"integrity": "sha1-F9jGWYbXvYAUpFKTA6K6C3aaidI=",
+			"requires": {
+				"kuromojin": "^1.2.1",
+				"textlint-rule-helper": "^1.1.4"
+			},
+			"dependencies": {
+				"textlint-rule-helper": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+					"integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
+					"requires": {
+						"unist-util-visit": "^1.1.0"
+					}
+				}
+			}
+		},
+		"textlint-rule-no-exclamation-question-mark": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-exclamation-question-mark/-/textlint-rule-no-exclamation-question-mark-1.0.2.tgz",
+			"integrity": "sha1-89gSz7rdyCJMpJfZs4tw2sVUiRw=",
+			"requires": {
+				"match-index": "^1.0.1",
+				"textlint-rule-helper": "^1.1.5"
+			},
+			"dependencies": {
+				"textlint-rule-helper": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+					"integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
+					"requires": {
+						"unist-util-visit": "^1.1.0"
+					}
+				}
+			}
+		},
+		"textlint-rule-no-hankaku-kana": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-hankaku-kana/-/textlint-rule-no-hankaku-kana-1.0.2.tgz",
+			"integrity": "sha1-bTqTaxjNcCHr/8qNQREYHcFZ9Mg=",
+			"requires": {
+				"match-index": "^1.0.1",
+				"textlint-rule-helper": "^1.1.5"
+			},
+			"dependencies": {
+				"textlint-rule-helper": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
+					"integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
+					"requires": {
+						"unist-util-visit": "^1.1.0"
+					}
+				}
+			}
+		},
+		"textlint-rule-no-mix-dearu-desumasu": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-3.0.3.tgz",
+			"integrity": "sha1-rEuBYLT0ZkSkpA1i/gHY23Zwt8M=",
+			"requires": {
+				"analyze-desumasu-dearu": "^3.1.0",
+				"textlint-rule-helper": "^2.0.0",
+				"unist-util-visit": "^1.1.0"
+			}
+		},
+		"textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet/-/textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet-1.0.1.tgz",
+			"integrity": "sha1-LRsNPO+l9SbmScjX0a8s3aapMzs=",
+			"requires": {
+				"match-index": "^1.0.1",
+				"moji": "^0.5.1",
+				"textlint-rule-helper": "^2.0.0"
+			}
+		},
+		"textlint-rule-no-nfd": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-nfd/-/textlint-rule-no-nfd-1.0.2.tgz",
+			"integrity": "sha512-n6tUx40/V6koDo78qqePHxSovuwSIKO0xwY3FCqVDbcfg9GxQCjde1twQJ99T3bs4LabhPOo/Pt3USaQ9XcTRQ==",
+			"requires": {
+				"match-index": "^1.0.3",
+				"textlint-rule-helper": "^2.1.1",
+				"unorm": "^1.4.1"
+			},
+			"dependencies": {
+				"textlint-rule-helper": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.1.1.tgz",
+					"integrity": "sha512-6fxgHzoJVkjl3LaC1b2Egi+5wbhG4i0pU0knJmQujVhxIJ3D3AcQQZPs457xKAi5xKz1WayYeTeJ5jrD/hnO7g==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.1",
+						"@textlint/types": "^1.1.2",
+						"structured-source": "^3.0.2",
+						"unist-util-visit": "^1.1.0"
+					}
+				}
+			}
+		},
+		"textlint-rule-no-start-duplicated-conjunction": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/textlint-rule-no-start-duplicated-conjunction/-/textlint-rule-no-start-duplicated-conjunction-2.0.2.tgz",
+			"integrity": "sha512-HydBbkWjnMn4KrnlpnusY1BGjIG+64UySxRCvRphUAIiuJL2nbkdrIIiOjwfQhllKUa7Sf33bs6RAcbEWjZVfg==",
+			"requires": {
+				"object-assign": "^4.0.1",
+				"sentence-splitter": "^3.0.6",
+				"textlint-rule-helper": "^2.0.0"
+			}
+		},
+		"textlint-rule-prefer-tari-tari": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/textlint-rule-prefer-tari-tari/-/textlint-rule-prefer-tari-tari-1.0.3.tgz",
+			"integrity": "sha512-86jSAIDX+o9zCANePo0OkRRgxJkfSoWrrJd6pF3P8X+AAYvlSYeq11HcnLfQIwodQLxkPpjJD7Y7XhmnGWSXRA==",
+			"requires": {
+				"nlcst-parse-japanese": "^1.1.2",
+				"nlcst-pattern-match": "^1.3.3",
+				"nlcst-to-string": "^2.0.1",
+				"textlint-rule-helper": "^2.0.0",
+				"textlint-util-to-string": "^2.1.1"
+			}
+		},
+		"textlint-rule-preset-japanese": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/textlint-rule-preset-japanese/-/textlint-rule-preset-japanese-4.0.4.tgz",
+			"integrity": "sha512-JTw3o65XccdlUV9KpPQXEOZTaoYm+vihLhrsbXkKkGWjpCEgdaAnnHueRJGx/vGlKb4v60Uef31xhHbat1w70Q==",
+			"requires": {
+				"@textlint-rule/textlint-rule-no-invalid-control-character": "^1.2.0",
+				"@textlint/module-interop": "^1.0.1",
+				"textlint-rule-max-ten": "^2.0.2",
+				"textlint-rule-no-double-negative-ja": "^1.0.3",
+				"textlint-rule-no-doubled-conjunction": "^1.0.2",
+				"textlint-rule-no-doubled-conjunctive-particle-ga": "^1.1.0",
+				"textlint-rule-no-doubled-joshi": "^3.0.0",
+				"textlint-rule-no-dropping-the-ra": "^1.1.2",
+				"textlint-rule-no-mix-dearu-desumasu": "^3.0.0",
+				"textlint-rule-no-nfd": "^1.0.1",
+				"textlint-rule-prh": "^5.2.0",
+				"textlint-rule-sentence-length": "^2.1.1"
+			}
+		},
+		"textlint-rule-preset-mobilus": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/textlint-rule-preset-mobilus/-/textlint-rule-preset-mobilus-0.0.3.tgz",
+			"integrity": "sha512-XvXBKyeGHWrKFTKhXW8bG/tL471gugaKBI6OxEM7U8vH3lvbZQH7bYXAgwZ62f0qMODgWjWXYkTRwPGBujFZ2w==",
+			"requires": {
+				"@textlint-ja/textlint-rule-no-insert-dropping-sa": "^1.0.1",
+				"@textlint-rule/textlint-rule-no-unmatched-pair": "^1.0.7",
+				"@textlint/module-interop": "^1.0.2",
+				"object-assign": "^4.1.1",
+				"textlint-rule-date-weekday-mismatch": "^1.0.5",
+				"textlint-rule-ja-hiragana-keishikimeishi": "^1.0.2",
+				"textlint-rule-ja-no-mixed-period": "^2.1.1",
+				"textlint-rule-ja-no-redundant-expression": "^3.0.1",
+				"textlint-rule-ja-no-weak-phrase": "^1.0.4",
+				"textlint-rule-ja-unnatural-alphabet": "^2.0.1",
+				"textlint-rule-max-comma": "^1.0.4",
+				"textlint-rule-max-kanji-continuous-len": "^1.1.1",
+				"textlint-rule-max-number-of-lines": "^1.0.3",
+				"textlint-rule-ng-word": "^1.0.0",
+				"textlint-rule-no-exclamation-question-mark": "^1.0.2",
+				"textlint-rule-no-hankaku-kana": "^1.0.2",
+				"textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "^1.0.1",
+				"textlint-rule-no-start-duplicated-conjunction": "^2.0.2",
+				"textlint-rule-prefer-tari-tari": "^1.0.3",
+				"textlint-rule-preset-japanese": "^4.0.4"
+			}
+		},
+		"textlint-rule-prh": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-5.3.0.tgz",
+			"integrity": "sha512-gdod+lL1SWUDyXs1ICEwvQawaSshT3mvPGufBIjF2R5WFPdKQDMsiuzsjkLm+aF+9d97dA6pFsiyC8gSW7mSgg==",
+			"requires": {
+				"@babel/parser": "^7.7.5",
+				"prh": "^5.4.4",
+				"textlint-rule-helper": "^2.1.1",
+				"untildify": "^3.0.3"
+			},
+			"dependencies": {
+				"textlint-rule-helper": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.1.1.tgz",
+					"integrity": "sha512-6fxgHzoJVkjl3LaC1b2Egi+5wbhG4i0pU0knJmQujVhxIJ3D3AcQQZPs457xKAi5xKz1WayYeTeJ5jrD/hnO7g==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.1",
+						"@textlint/types": "^1.1.2",
+						"structured-source": "^3.0.2",
+						"unist-util-visit": "^1.1.0"
+					}
+				}
+			}
+		},
+		"textlint-rule-sentence-length": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/textlint-rule-sentence-length/-/textlint-rule-sentence-length-2.2.0.tgz",
+			"integrity": "sha512-0C7XZvqcdDwBQC1Sfyr47uDAChH0dO3O4gjxG4C/cwRFK8cyjIic8h7g+xaN7c9x+4OoMz+89SksuaHLo5UvqQ==",
+			"requires": {
+				"@textlint/regexp-string-matcher": "^1.1.0",
+				"sentence-splitter": "^3.0.11",
+				"textlint-rule-helper": "^2.1.1",
+				"textlint-util-to-string": "^3.0.0"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+				},
+				"is-plain-obj": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+				},
+				"textlint-rule-helper": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.1.1.tgz",
+					"integrity": "sha512-6fxgHzoJVkjl3LaC1b2Egi+5wbhG4i0pU0knJmQujVhxIJ3D3AcQQZPs457xKAi5xKz1WayYeTeJ5jrD/hnO7g==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.1",
+						"@textlint/types": "^1.1.2",
+						"structured-source": "^3.0.2",
+						"unist-util-visit": "^1.1.0"
+					}
+				},
+				"textlint-util-to-string": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-3.0.0.tgz",
+					"integrity": "sha512-NLvumkbmdynXZIYdv9JR2amjsT8ZiPPmr/6vFLcJU2NmZTtZoE8DfEOW9BtD/pbUAQaukwGjbEFc93lBIL1o/w==",
+					"requires": {
+						"@textlint/ast-node-types": "^4.2.4",
+						"@types/structured-source": "^3.0.0",
+						"rehype-parse": "^6.0.1",
+						"structured-source": "^3.0.2",
+						"unified": "^8.4.0"
+					}
+				},
+				"unified": {
+					"version": "8.4.2",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+					"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+					"requires": {
+						"bail": "^1.0.0",
+						"extend": "^3.0.0",
+						"is-plain-obj": "^2.0.0",
+						"trough": "^1.0.0",
+						"vfile": "^4.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
+					"integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
+					"requires": {
+						"@types/unist": "^2.0.2"
+					}
+				},
+				"vfile": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
+					"integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"is-buffer": "^2.0.0",
+						"replace-ext": "1.0.0",
+						"unist-util-stringify-position": "^2.0.0",
+						"vfile-message": "^2.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
+					"integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^2.0.0"
+					}
+				}
+			}
+		},
+		"textlint-tester": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/textlint-tester/-/textlint-tester-5.0.1.tgz",
+			"integrity": "sha512-MKN38gIQ9/Q3nKg1cnKUVl81bjsfoqy6yq7qptvf3733Ng22K2KoMmTyk8s8C/y7SGx8pN+idsO86DCGEB8q7w==",
+			"requires": {
+				"@textlint/feature-flag": "^3.0.5",
+				"@textlint/kernel": "^3.0.0",
+				"textlint": "^11.0.1"
+			}
+		},
+		"textlint-util-to-string": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-2.1.1.tgz",
+			"integrity": "sha512-PW6rXqLNGL3xZ6d5/INrX+pt8qbffmeDPLcvkBOlfNpDRFhVvNNjFmZXH86ZQjrOz9t/nNZDBXqnzqJuioJbSQ==",
+			"requires": {
+				"object-assign": "^4.0.1",
+				"structured-source": "^3.0.2"
+			}
+		},
 		"through2": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -6281,7 +8540,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -6305,6 +8563,31 @@
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
 		},
+		"traverse": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+		},
+		"trim": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+		},
+		"trim-trailing-lines": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+			"integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
+		},
+		"trough": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
+		},
+		"try-resolve": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+			"integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI="
+		},
 		"tryer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -6322,6 +8605,14 @@
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
 			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
 			"dev": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
 		},
 		"type-detect": {
 			"version": "4.0.8",
@@ -6342,8 +8633,16 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"unherit": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+			"integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
+			"requires": {
+				"inherits": "^2.0.0",
+				"xtend": "^4.0.0"
+			}
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
@@ -6373,6 +8672,19 @@
 			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
 			"dev": true
 		},
+		"unified": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+			"requires": {
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^2.0.0",
+				"x-is-string": "^0.1.0"
+			}
+		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -6384,6 +8696,11 @@
 				"is-extendable": "^0.1.1",
 				"set-value": "^2.0.1"
 			}
+		},
+		"unique-concat": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/unique-concat/-/unique-concat-0.2.2.tgz",
+			"integrity": "sha1-khD5vcqsxeHjkpSQ18AZ35bxhxI="
 		},
 		"unique-filename": {
 			"version": "1.1.1",
@@ -6402,6 +8719,66 @@
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
+		},
+		"unist-types": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/unist-types/-/unist-types-1.1.4.tgz",
+			"integrity": "sha1-mTWoPBO6YDjS7wB5Zkx+cekJSX8="
+		},
+		"unist-util-filter": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-0.2.1.tgz",
+			"integrity": "sha1-4veHaCiQOmqTCONiBR+GsU81tUU=",
+			"requires": {
+				"flatmap": "0.0.3",
+				"unist-util-is": "^1.0.0"
+			},
+			"dependencies": {
+				"unist-util-is": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-1.0.0.tgz",
+					"integrity": "sha1-THs8XA9qqWNkAFb+Sve1/P27jvA="
+				}
+			}
+		},
+		"unist-util-is": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+		},
+		"unist-util-remove-position": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+			"integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+			"requires": {
+				"unist-util-visit": "^1.1.0"
+			}
+		},
+		"unist-util-stringify-position": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+		},
+		"unist-util-visit": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+			"requires": {
+				"unist-util-visit-parents": "^2.0.0"
+			}
+		},
+		"unist-util-visit-parents": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+			"requires": {
+				"unist-util-is": "^3.0.0"
+			}
+		},
+		"unorm": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+			"integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -6448,6 +8825,11 @@
 					"dev": true
 				}
 			}
+		},
+		"untildify": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+			"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
 		},
 		"upath": {
 			"version": "1.2.0",
@@ -6514,8 +8896,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"utils-merge": {
 			"version": "1.0.1",
@@ -6529,11 +8910,90 @@
 			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
 			"dev": true
 		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"variable-diff": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/variable-diff/-/variable-diff-1.1.0.tgz",
+			"integrity": "sha1-0r1cZtt2wTh52W5qMG7cmJ35eNo=",
+			"requires": {
+				"chalk": "^1.1.1",
+				"object-assign": "^4.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
 		"vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
 			"dev": true
+		},
+		"vfile": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+			"requires": {
+				"is-buffer": "^1.1.4",
+				"replace-ext": "1.0.0",
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
+			}
+		},
+		"vfile-location": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+			"integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
+		},
+		"vfile-message": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+			"requires": {
+				"unist-util-stringify-position": "^1.1.1"
+			}
 		},
 		"vm-browserify": {
 			"version": "1.1.2",
@@ -6551,6 +9011,11 @@
 				"graceful-fs": "^4.1.2",
 				"neo-async": "^2.5.0"
 			}
+		},
+		"web-namespaces": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+			"integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
 		},
 		"webpack": {
 			"version": "4.41.5",
@@ -6771,6 +9236,11 @@
 				}
 			}
 		},
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+		},
 		"worker-farm": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -6794,8 +9264,15 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+			"requires": {
+				"mkdirp": "^0.5.1"
+			}
 		},
 		"ws": {
 			"version": "6.2.1",
@@ -6806,11 +9283,20 @@
 				"async-limiter": "~1.0.0"
 			}
 		},
+		"x-is-string": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+		},
+		"xml-escape": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+			"integrity": "sha1-OQTBQ/qOs6ADDsZG0pAqLxtwbEQ="
+		},
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "4.0.0",
@@ -6883,6 +9369,11 @@
 					}
 				}
 			}
+		},
+		"zlibjs": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.2.0.tgz",
+			"integrity": "sha1-riDwYkMpPYXCVVYxifmxL1s7oaA="
 		}
 	}
 }

--- a/packages/textlint-browser-runner/package.json
+++ b/packages/textlint-browser-runner/package.json
@@ -40,6 +40,7 @@
     "@babel/register": "^7.8.3",
     "babel-loader": "^8.0.6",
     "mocha": "^7.0.1",
+    "moment-locales-webpack-plugin": "^1.1.2",
     "sinon": "^8.1.1",
     "terser-webpack-plugin": "^2.3.4",
     "webpack": "^4.41.5",

--- a/packages/textlint-browser-runner/webpack.config.js
+++ b/packages/textlint-browser-runner/webpack.config.js
@@ -1,3 +1,4 @@
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const path = require('path');
 module.exports = {
@@ -45,4 +46,9 @@ module.exports = {
         }
       })]
   },
+  plugins: [
+    new MomentLocalesPlugin({
+      localesToKeep: ['en', 'ja', 'es', 'fr', 'zh-cn', 'zh-hk', 'zh-tw',], // https://github.com/azu/textlint-rule-date-weekday-mismatch/blob/master/src/textlint-rule-date-weekday-mismatch.js#L10
+    }),
+  ]
 };

--- a/packages/textlint-browser-runner/webpack.development.config.js
+++ b/packages/textlint-browser-runner/webpack.development.config.js
@@ -1,4 +1,5 @@
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const path = require('path');
 module.exports = {
   mode: 'development',
@@ -32,6 +33,9 @@ module.exports = {
     ]
   },
   plugins: [
+    new MomentLocalesPlugin({
+      localesToKeep: ['en', 'ja', 'es', 'fr', 'zh-cn', 'zh-hk', 'zh-tw',], // https://github.com/azu/textlint-rule-date-weekday-mismatch/blob/master/src/textlint-rule-date-weekday-mismatch.js#L10
+    }),
     new BundleAnalyzerPlugin()
   ]
 };


### PR DESCRIPTION
Remove unused locales except `en`, `ja`, `es`, `fr`, `zh-cn`, `zh-hk`, `zh-tw` with moment-locales-webpack-plugin
Depends on `textlint-rule-date-weekday-mismatch` supported language
See https://github.com/azu/textlint-rule-date-weekday-mismatch/blob/master/src/textlint-rule-date-weekday-mismatch.js#L10

#4 